### PR TITLE
Fix farmoni-master cli option parameter for monitoring

### DIFF
--- a/farmoni_master/farmoni_master.go
+++ b/farmoni_master/farmoni_master.go
@@ -74,7 +74,7 @@ func parseRequest() {
         delVMAZURE = flag.Bool("delvm-azure", false, "delete all servers in AZURE: -delvm-azure")
 
         listvm = flag.Bool("listvm", false, "report server list: -listvm")
-        monitoring = flag.Bool("monitoring", false, "report all server' resources status: -monitoring")
+        monitoring = flag.Bool("monitor", false, "report all server' resources status: -monitor")
 
         flag.Parse()
 }
@@ -104,7 +104,7 @@ func main() {
         fmt.Println("go run farmoni_master.go -addvm-azure=5")
         fmt.Println("")
         fmt.Println("go run farmoni_master.go -listvm")
-        fmt.Println("go run farmoni_master.go -monitoring")
+        fmt.Println("go run farmoni_master.go -monitor")
 
 	// to delete all servers in aws
         fmt.Println("")


### PR DESCRIPTION
Fixes #1

son@son:~/go/src/github.com/cloud-barista/poc-farmoni/farmoni_master$ ./farmoni_master 

go run farmoni_master.go -addvm-aws=10
go run farmoni_master.go -addvm-gcp=5
go run farmoni_master.go -addvm-azure=5

go run farmoni_master.go -listvm
**go run farmoni_master.go -monitor**

go run farmoni_master.go -delvm-aws
go run farmoni_master.go -delvm-gcp
go run farmoni_master.go -delvm-azure