### PR TITLE
Enhance CLI to support detail outputs and delete all VMs

### DIFF
--- a/farmoni_master/etcdhandler/etcdhandler.go
+++ b/farmoni_master/etcdhandler/etcdhandler.go
@@ -101,9 +101,11 @@ func ServerList(ctx context.Context, cli *clientv3.Client) []*string {
 	for k, ev := range resp.Kvs {
 		//fmt.Printf("%s : %s\n", strings.Trim(string(ev.Key), "/server/"), ev.Value)
 		// /server/aws/i-1234567890abcdef0/129.254.175:2019
+
 		tmpStr := strings.Trim(string(ev.Key), "/server/")
-                tmpStrs := strings.Split(string(tmpStr), "/")
-                serverList[k] = &tmpStrs[2]
+                //tmpStrs := strings.Split(string(tmpStr), "/")
+                //serverList[k] = &tmpStrs[2]
+		serverList[k] = &tmpStr
 	}
 
 	return serverList

--- a/farmoni_master/farmoni_master.go
+++ b/farmoni_master/farmoni_master.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"time"
 	"log"
+	"strings"
 	"strconv"
         "google.golang.org/grpc"
         pb "github.com/cloud-barista/poc-farmoni/grpc_def"
@@ -124,14 +125,19 @@ func getInteractiveRequest() {
                         fmt.Println("select within 1-4")
 		}
 	case command == 2:
-                selCsp := 0
-                fmt.Println("[Select cloud service provider (1:aws, 2:gcp, 3:azure, 4:TBD]")
+                selCsp := -1
+		fmt.Println("[Select cloud service provider (0: all, 1:aws, 2:gcp, 3:azure, 4:TBD]")
                 fmt.Print("Your section : ")
                 fmt.Scanln(&selCsp)
 
                 switch {
-                case selCsp == 0:
+                case selCsp == -1:
                         fmt.Println("nothing was selected")
+                case selCsp == 0:
+                        fmt.Println("Delete all VMs for all CPSs")
+                        *delVMAWS = true
+			*delVMGCP = true
+			*delVMAZURE = true
                 case selCsp == 1:
                         fmt.Println("Delete all VMs in aws")
                         *delVMAWS = true
@@ -750,8 +756,10 @@ func serverList() {
 	list := getServerList()
 	fmt.Print("######### all server list....(" + strconv.Itoa(len(list)) + ")\n")
 
+
 	for _, v := range list {
-		fmt.Println(*v)
+		vs := strings.Split(string(*v), "/")
+		fmt.Println("[CSP] " + vs[0] + "\t/ [VmID] "+ vs[1] +"\t/ [IP] " + vs[2])
 	}	
 }
 
@@ -813,7 +821,11 @@ func monitoringAll() {
 	for {
 		list := getServerList()
 		for _, v := range list {
-			monitoringServer(*v)
+			vs := strings.Split(string(*v), "/")
+			println("-----monitoiring for------")
+			fmt.Println("[CSP] " + vs[0] + "\t/ [VmID] "+ vs[1] +"\t/ [IP] " + vs[2])
+
+			monitoringServer(vs[2])
 			println("-----------")
 		}
                 println("==============================")


### PR DESCRIPTION
This PR is to enhance CLI.

Now users can check list of VMs with additional information.


```
son@son:~/go/src/github.com/cloud-barista/poc-farmoni/farmoni_master$ ./farmoni_master 
[Select opt (1:create-vm, 2:delete-vm, **3:list-vm**, 4:monitor-vm]
Your section : 3
3
connected to etcd - 10.0.2.15:2379
######### all server list....(4)
**[CSP] aws	/ [VmID] i-0fe5ad61c40e9126d	/ [IP] 54.180.133.206:2019
[CSP] aws	/ [VmID] i-0f143419fcbc31e19	/ [IP] 13.125.157.79:2019
[CSP] aws	/ [VmID] i-0e7a2cec25f4992b7	/ [IP] 52.78.235.33:2019
[CSP] aws	/ [VmID] i-03cc9fe163778cff2	/ [IP] 13.125.143.199:2019**
```


Also, this PR supports deleting all VMs from all CSPs.

```
[Select opt (1:create-vm, 2:delete-vm, 3:list-vm, 4:monitor-vm]
Your section : 2
2
[Select cloud service provider (**0: all**, 1:aws, 2:gcp, 3:azure, 4:TBD]
Your section : 0

> Delete all VMs for all CPSs

######### delete all servers in AWS....
connected to etcd - 10.0.2.15:2379
connected to etcd - 10.0.2.15:2379
######### delete aws all Server....
deleted all aws server list...
######### delete all servers in GCP....
connected to etcd - 10.0.2.15:2379
connected to etcd - 10.0.2.15:2379
######### delete gcp all Server....
deleted all gcp server list...
######### delete all servers in AZURE....
2019-05-31 17:33:05.096585 I | deleting resource group 'etri-shson-VMGroup'
connected to etcd - 10.0.2.15:2379
######### delete azure all Server....
deleted all azure server list...

```
